### PR TITLE
Use pflag in tests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,12 +15,12 @@
 package e2e
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"testing"
 
 	operatorFramework "github.com/kinvolk/habitat-operator/test/e2e/framework"
+	flag "github.com/spf13/pflag"
 )
 
 var framework *operatorFramework.Framework


### PR DESCRIPTION
The pflag package is used elsewhere because it allows us to set
shorthands (e.g. -v for --verbose).

We now use in this test file as well for consistency, although we're not
using any of its differentiating features.

Closes #78.