### PR TITLE
Fix apiVersion in deployment manifest template

### DIFF
--- a/helm/habitat-operator/templates/deployment.yaml
+++ b/helm/habitat-operator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
It should be the same as the apiVersion in examples/habitat-operator-deployment.yml