### PR TITLE
Fix config example

### DIFF
--- a/examples/config/habitat.yml
+++ b/examples/config/habitat.yml
@@ -16,7 +16,7 @@ spec:
   image: kinvolk/redis-hab
   count: 1
   service:
-    name: db
+    name: redis
     topology: standalone
     group: redisdb
     # Create Secret with the initial configuration you want.


### PR DESCRIPTION
The service name of the redis Habitat config example was wrong, so when
the user.toml path was formed the user.toml was placed in the wrong pkg
directory.