### PR TITLE
Run tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    working_directory: ~/.go_workspace/src/github.com/habitat-sh/habitat-operator
+    steps:
+      - checkout
+      - run:
+          name: setup
+          environment:
+            K8S_VERSION: v1.9.0
+          command: |
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+            curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            sudo minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
+            sudo chown -R $USER $HOME/.kube
+            sudo chgrp -R $USER $HOME/.kube
+            sudo chown -R $USER $HOME/.minikube
+            sudo chgrp -R $USER $HOME/.minikube
+      - run:
+          name: unit tests
+          command: make test
+      - run:
+          name: create image
+          command: make TAG=testing image
+      - run:
+          name: waiting for kubernetes to be ready
+          command: |
+            JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+            until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+              sleep 1
+            done
+      - run:
+          name: e2e tests
+          command: make TESTIMAGE=habitat/habitat-operator:testing e2e
+      - run:
+          name: print logs
+          command: kubectl logs -lhabitat=true --tail=100
+          when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,11 @@ jobs:
           name: setup
           environment:
             K8S_VERSION: v1.9.0
+            CHANGE_MINIKUBE_NONE_USER: true
           command: |
             curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
             curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-            sudo minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
-            sudo chown -R $USER $HOME/.kube
-            sudo chgrp -R $USER $HOME/.kube
-            sudo chown -R $USER $HOME/.minikube
-            sudo chgrp -R $USER $HOME/.minikube
+            sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
       - run:
           name: unit tests
           command: make test


### PR DESCRIPTION
This PR enables the running of tests on CircleCI.

The main advantage is that, in case of a failing build, we can SSH into the machine.

I think we should run both CircleCI and Travis, evaluate the respective benefits, and then converge on one solution.

**NOTE**: ~I tried using the `CHANGE_MINIKUBE_NONE_USER=true` env variable, but it somehow got ignored. Therefore I resorted to manual `chown`/`chgrp`.~

**NOTE**: If https://github.com/habitat-sh/habitat-operator/pull/211 is merged, this needs to be updated to also run the `update-codegen.sh` script.