### PR TITLE
Make it possible to use sudo when calling docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMAGE := $(if $(HUB),$(HUB)/)$(DOCKER_ORG)/habitat-operator
 BIN_PATH := habitat-operator
 TAG := $(shell git describe --tags --always)
 TESTIMAGE :=
+SUDO :=
 
 build:
 	go build -i github.com/$(GITHUB_ORG)/habitat-operator/cmd/habitat-operator
@@ -14,7 +15,7 @@ linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s" -o $(BIN_PATH) github.com/$(GITHUB_ORG)/habitat-operator/cmd/habitat-operator
 
 image: linux
-	docker build -t "$(IMAGE):$(TAG)" .
+	$(SUDO) docker build -t "$(IMAGE):$(TAG)" .
 
 test:
 	go test -v $(shell go list ./... | grep -v /vendor/ | grep -v /test/)


### PR DESCRIPTION
Docker on Fedora requires root to talk to it, so `make image` always
fails there currently. But let's not just hardcode `sudo` to fix it,
because other distros may be more convenient here by not requiring
root when talking to docker, so sudo here is pointless. With this
change, we can do `make SUDO=sudo image` on Fedora to make it work.