### PR TITLE
Try to make TestBind a bit less flaky

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -147,10 +147,23 @@ func TestBind(t *testing.T) {
 		if strings.Contains(actualMsg, expectedMsg) {
 			break
 		}
+
+		fail := func() {
+			t.Fatalf("Configuration update did not go through. Expected: \"%s\", got: \"%s\"", expectedMsg, actualMsg)
+		}
+
 		select {
 		case <-timer.C:
-			t.Fatalf("Configuration update did not go through. Expected: \"%s\", got: \"%s\"", expectedMsg, actualMsg)
+			fail()
 		case <-ticker.C:
+			// This is to avoid infinite loops when go
+			// decides to always pick the ticker channel,
+			// even when timer channel is ready too.
+			select {
+			case <-timer.C:
+				fail()
+			default:
+			}
 		}
 	}
 }


### PR DESCRIPTION
This tries to query the server to figure out whether the user.toml
file was updated in 10 second intervals for 2 minutes instead of
waiting for 1 minute and bail out if it wasn't updated yet. Updating
user.toml through k8s Secret may take some time.

Tries to fix #232.