### PR TITLE
stateful sets: Set UpdateStrategy to RollingUpdate

### DIFF
--- a/pkg/controller/stateful_sets.go
+++ b/pkg/controller/stateful_sets.go
@@ -134,6 +134,9 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta1
 					},
 				},
 			},
+			UpdateStrategy: appsv1beta1.StatefulSetUpdateStrategy{
+				Type: appsv1beta1.StatefulSetUpdateStrategyType(appsv1beta1.RollingUpdateDeploymentStrategyType),
+			},
 		},
 	}
 


### PR DESCRIPTION
The default value is supposed to be `RollingUpdate` if unspecified but
this doesn't seem to be the case with `v1beta1` at the moment. Also
updating to `v1beta2` is not possible since this breaks support for
Kubernetes 1.7.0.

We should ideally move to `v1` once we support Kubernetes 1.10 and
then can drop support for 1.7.

Closes #235.