### PR TITLE
Fix: Use correct mongodb image

### DIFF
--- a/examples/national_parks/README.md
+++ b/examples/national_parks/README.md
@@ -10,11 +10,5 @@ After the Habitat operator is up and running, execute the following command from
 kubectl create -f examples/national_parks/habitat.yml
 ```
 
-This will deploy two `Habitat`s, the national parks Java app and a MongoDB instance. By default, the MongoDB database instance would [listen
-on port
-27017](https://github.com/habitat-sh/core-plans/blob/master/mongodb/default.toml#L59),
-but we change this with the configuration stored in the `user-toml`.
+This will deploy two `Habitat`s, the national parks Java app and a MongoDB instance.
 
-The Go web app displays the overridden database port number, and it can be
-accessed under port `30001`. When running on minikube, its IP can be retrieved
-with `minikube ip`.

--- a/examples/national_parks/habitat.yml
+++ b/examples/national_parks/habitat.yml
@@ -1,18 +1,19 @@
 apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
-  name: db
+  name: national-parks-db
 spec:
-  image: habitat/mongodb
+  image: habitat/np-mongodb
   count: 1
   service:
-    name: mongodb
+    name: np-mongodb
     topology: standalone
+    group: default
 ---
 apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
-  name: configured-national-parks
+  name: national-parks-app
 spec:
   image: habitat/national-parks
   count: 1
@@ -21,7 +22,7 @@ spec:
     topology: standalone
     bind:
       - name: database
-        service: mongodb
+        service: np-mongodb
         group: default
 ---
 apiVersion: v1
@@ -30,7 +31,7 @@ metadata:
   name: national-parks
 spec:
   selector:
-    habitat-name: configured-national-parks
+    habitat-name: national-parks-app
   type: NodePort
   ports:
   - name: web


### PR DESCRIPTION
In order for this example to work, the application needs to have access
to a mongo instance with the National Parks data.  This is provided by
the `habitat/np-mongodb` plan, currently maintained by CFT.

This includes a post-run hook that drops the demo database, creates a
nationalparks database, and runs a mongo import using JSON which
specifies the location of the parks.

There is some question over whether a sleep is needed in the post-run
hook to ensure that Tomcat has come up in time.  This smells fishy, and
should be looked at.

Signed-off-by: Stephen Nelson-Smith <stephen.nelsonsmith@ticketmaster.co.uk>