### PR TITLE
add channel to supervisor

### DIFF
--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -140,6 +140,12 @@ type ServiceV1beta2 struct {
 	// Name is the name of the Habitat service that this Habitat object represents.
 	// This field is used to mount the user.toml file in the correct directory under /hab/user/ in the Pod.
 	Name string `json:"name"`
+	// Channel is the value of the --channel flag for the hab client.
+	// It can be used to track upstream packages in builder channels but will never be used directly by the supervisor.
+	// The should only be used in conjunction with the habitat updater https://github.com/habitat-sh/habitat-updater
+	// Defaults to `stable`.
+	// +optional
+	Channel *string `json:"channel,omitempty"`
 }
 
 type Bind struct {

--- a/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
@@ -234,6 +234,15 @@ func (in *ServiceV1beta2) DeepCopyInto(out *ServiceV1beta2) {
 		*out = make([]Bind, len(*in))
 		copy(*out, *in)
 	}
+	if in.Channel != nil {
+		in, out := &in.Channel, &out.Channel
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/controller/v1beta2/stateful_sets.go
+++ b/pkg/controller/v1beta2/stateful_sets.go
@@ -45,6 +45,13 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta1
 			"--group", *hs.Service.Group)
 	}
 
+	if hs.Service.Channel != nil {
+		// When a service is started without explicitly naming the channel,
+		// it's assigned to the stable channel.
+		habArgs = append(habArgs,
+			"--channel", *hs.Service.Channel)
+	}
+
 	// As we want to label our pods with the
 	// topology type we set standalone as the default one.
 	// We do not need to pass this to habitat, as if no topology


### PR DESCRIPTION
[Habitat updater](https://github.com/habitat-sh/habitat-updater) is a service that runs inside of a k8's cluster to watch for changes in pods running habitat services and reconcile any updates from builder. It does this by querying the k8's pods api for anything with a `habitat=true` label. Then it queries the supervisors running in those pods for what services they are running. Once it has a list of services, it asks builder for the most recent version of those packages in the stable channel. This is undesirable if you want to run a version of your package from the dev/acceptance channel. 

This change will allow you to tell the Habitat supervisor what channel it should be pinned to with the `--channel` flag. The update service will have to be modified after this change to get the channel from the supervisor and query builder accordingly.

![](https://media3.giphy.com/media/3oJtg0Ex1lO37eySD6/200w.gif)
Signed-off-by: Elliott Davis <elliott@excellent.io>