### PR TITLE
Remove dependency on pflag library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -428,6 +428,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "99212a1cfe34e275e246d205a124895d753180eef17ca71592ba2a63348548f4"
+  inputs-digest = "4756026b77d2dbae76c2ebaeb6c37f9c142cfc8c95d52a484b1325fce948f9cc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/habitat-operator/main.go
+++ b/cmd/habitat-operator/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"os"
 	"os/signal"
 	"runtime"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	flag "github.com/spf13/pflag"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeinformers "k8s.io/client-go/informers"
@@ -48,7 +48,7 @@ type Clientsets struct {
 func run() int {
 	// Parse config flags.
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	verbose := flag.BoolP("verbose", "v", false, "Enable verbose logging.")
+	verbose := flag.Bool("verbose", false, "Enable verbose logging.")
 	flag.Parse()
 
 	// Set up logging.


### PR DESCRIPTION
The only advantage was that it allowed us to define a shorthand (`-v`)
for the `--verbose` option, but we barely used that flag anyway, so the
additional overhead wasn't worth it.

Closes #78.
Supersedes and closes #170.

Signed-off-by: Lorenzo Manacorda <lorenzo@kinvolk.io>