### PR TITLE
Mark item done after validity check

### DIFF
--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -528,8 +528,6 @@ func (hc *HabitatController) processNextItem() bool {
 		return false
 	}
 
-	defer hc.queue.Done(key)
-
 	k, ok := key.(string)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert key", "obj", key)
@@ -541,8 +539,9 @@ func (hc *HabitatController) processNextItem() bool {
 		return false
 	}
 
-	err := hc.conform(k)
-	if err != nil {
+	defer hc.queue.Done(key)
+
+	if err := hc.conform(k); err != nil {
 		level.Error(hc.logger).Log("msg", "Habitat could not be synced, requeueing", "err", err, "obj", k)
 
 		hc.queue.AddRateLimited(k)

--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -533,6 +533,11 @@ func (hc *HabitatController) processNextItem() bool {
 	k, ok := key.(string)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert key", "obj", key)
+
+		// The item in the queue does not have the expected type, so we remove it
+		// from the queue as there's no point in processing it.
+		hc.queue.Forget(k)
+
 		return false
 	}
 


### PR DESCRIPTION
This PR improves two things about the way in which we handle the queue:

* Only mark items as done after we've checked them for validity (i.e. checked that they are strings)
* Call `Forget` for invalid items, so that we don't get them in the queue again.