### PR TITLE
controller: print custom version string instead of pointer

### DIFF
--- a/pkg/controller/v1beta1/utils.go
+++ b/pkg/controller/v1beta1/utils.go
@@ -175,6 +175,6 @@ func checkCustomVersionMatch(h *habv1beta1.Habitat) error {
 		return nil
 	}
 
-	return fmt.Errorf("wrong CustomVersion: %v", v)
+	return fmt.Errorf("wrong CustomVersion: %v", *v)
 
 }

--- a/pkg/controller/v1beta2/utils.go
+++ b/pkg/controller/v1beta2/utils.go
@@ -156,7 +156,7 @@ func checkCustomVersionMatch(h *habv1beta1.Habitat) error {
 	if v == nil {
 		err = fmt.Errorf("missing CustomVersion")
 	} else if *v != "v1beta2" {
-		err = fmt.Errorf("wrong CustomVersion: %s", v)
+		err = fmt.Errorf("wrong CustomVersion: %s", *v)
 	}
 
 	return err


### PR DESCRIPTION
Otherwise the error message will include a memory address which is not
very useful.