### PR TITLE
Dockerfile: start from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM scratch
 
 COPY habitat-operator /habitat-operator
 
-ENTRYPOINT ["/habitat-operator"]
+ENTRYPOINT ["/habitat-operator", "-logtostderr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM scratch
 
 COPY habitat-operator /habitat-operator
 


### PR DESCRIPTION
So we only have the static binary in the image and avoid including
alpine data.

This reduces the image size from 25.7MB to 21.7MB.

Closes #276 