### PR TITLE
Use labels on examples

### DIFF
--- a/examples/bind-config/habitat.yml
+++ b/examples/bind-config/habitat.yml
@@ -13,6 +13,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-bind-configured-db
+  labels:
+    source: operator-example
+    app: bind-configured-db
 customVersion: v1beta2
 spec:
   v1beta2:
@@ -29,6 +32,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-bind-configured-web-app
+  labels:
+    source: operator-example
+    app: bind-configured-web-app
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/bind/habitat.yml
+++ b/examples/bind/habitat.yml
@@ -1,7 +1,10 @@
 apiVersion: habitat.sh/v1beta1
-kind: Habitat 
+kind: Habitat
 metadata:
   name: db
+  labels:
+    source: operator-example
+    app: db
 customVersion: v1beta2
 spec:
   v1beta2:
@@ -15,6 +18,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: web-app
+  labels:
+    source: operator-example
+    app: web-app
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/config/habitat.yml
+++ b/examples/config/habitat.yml
@@ -12,6 +12,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-configured-habitat
+  labels:
+    source: operator-example
+    app: configured-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/encrypted/habitat.yml
+++ b/examples/encrypted/habitat.yml
@@ -15,6 +15,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-encrypted-habitat
+  labels:
+    source: operator-example
+    app: encrypted-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/env-vars/habitat.yml
+++ b/examples/env-vars/habitat.yml
@@ -2,6 +2,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-env-vars-habitat
+  labels:
+    source: operator-example
+    app: env-vars-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/leader/habitat.yml
+++ b/examples/leader/habitat.yml
@@ -2,6 +2,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-leader-follower-habitat
+  labels:
+    source: operator-example
+    app: leader-follower-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/namespaced/habitat.yml
+++ b/examples/namespaced/habitat.yml
@@ -8,6 +8,9 @@ kind: Habitat
 metadata:
   name: example-namespaced-habitat
   namespace: example-namespace
+  labels:
+    source: operator-example
+    app: namespaced-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/persisted/habitat.yml
+++ b/examples/persisted/habitat.yml
@@ -2,6 +2,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-persistent-habitat
+  labels:
+    source: operator-example
+    app: persistent-habitat
 customVersion: v1beta2
 spec:
   v1beta2:

--- a/examples/standalone/habitat.yml
+++ b/examples/standalone/habitat.yml
@@ -2,6 +2,9 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: example-standalone-habitat
+  labels:
+    source: operator-example
+    app: standalone-habitat
 customVersion: v1beta2
 spec:
   v1beta2:


### PR DESCRIPTION
Fixes #154 

We need to improve the naming of our example Habitats.
At the moment, we sometimes use example-x-y-z.
This is fine in some cases (example-standalone-habitat), but then we also use "go" in other cases.
From a discoverability/UX point of view, using labels would free us to use the name that makes the most sense,
but still letting the user clearly know that the Habitat is from the operator and is an example.
