### PR TITLE
examples: Fix incorrect mount path for persistent

### DIFF
--- a/examples/persisted/habitat.yml
+++ b/examples/persisted/habitat.yml
@@ -12,11 +12,11 @@ spec:
     persistentStorage:
       # the size of the volume that will be mounted in each Pod
       size: 1Gi
-      # a StorageClass object with name "standard" must be created beforehand by
+      # a StorageClass object with name "example-sc" must be created beforehand by
       # the cluster administrator
       storageClassName: example-sc
       # the location under which the volume will be mounted
-      mountPath: /tmp/foobar
+      mountPath: /hab/svc/redis/data
     env:
       - name: HAB_REDIS
         # this is needed to make redis accept connections from other hosts


### PR DESCRIPTION
The mount path should be /hab/svc/redis/data instead of a tmp path.
This commit also updates an outdated comment.

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>