### PR TITLE
Makefile: Fix clean-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ e2e:
 
 clean-test:
 	kubectl delete namespace testing-v1beta1
-	kubectl delete clusterrolebinding habitat-operator
-	kubectl delete clusterrole habitat-operator
+	kubectl delete clusterrolebinding habitat-operator-v1beta1
+	kubectl delete clusterrole habitat-operator-v1beta1
 
 update-version:
 	find examples -name "*.yml" -type f \


### PR DESCRIPTION
Fixes this continuous loop of errors that occur after running e2e test for the first time.

```
habitat-operator git:(kosy/minikube-dependency) make TESTIMAGE=habitat/redis-hab e2e
go test -v ./test/e2e/... --image "habitat/redis-hab" --kubeconfig ~/.kube/config --ip "$(minikube ip)"
clusterroles.rbac.authorization.k8s.io "habitat-operator-v1beta1" already exists
FAIL    github.com/habitat-sh/habitat-operator/test/e2e/v1beta1    0.079s
?       github.com/habitat-sh/habitat-operator/test/e2e/v1beta1/framework    [no test files]
make: *** [Makefile:26: e2e] Error 1

➜  habitat-operator git:(kosy/minikube-dependency) make clean-test                     
kubectl delete namespace testing-v1beta1
namespace "testing-v1beta1" deleted
kubectl delete clusterrolebinding habitat-operator
Error from server (NotFound): clusterrolebindings.rbac.authorization.k8s.io "habitat-operator" not found
make: *** [Makefile:30: clean-test] Error 1
```