### PR TITLE
CI: Skip tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check for changes in documentation and examples
+          command: ./hack/check-skippable-changes.sh
+      - run:
           name: setup
           environment:
             K8S_VERSION: v1.10.0

--- a/hack/check-skippable-changes.sh
+++ b/hack/check-skippable-changes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script checks to see if changes only affect documentation and examples
+# and skips running tests if that's the case
+
+set -eu
+
+# Finds the branching point of two commits.
+# For example, let B and D be two commits, and their ancestry graph as A -> B, A -> C -> D.
+# Given commits B and D, it returns A.
+# https://github.com/rkt/rkt/blob/2de014aa1a8f1d9e92bc869e7d666679f2e45a1d/tests/build-and-run-tests.sh#L31-L38
+function getBranchingPoint {
+    diff --old-line-format='' --new-line-format='' \
+        <(git rev-list --first-parent "${1}") \
+            <(git rev-list --first-parent "${2}") | head -1
+}
+
+DOC_EXAMPLE_CHANGE_PATTERN=(
+            '-e' '^doc/'
+            '-e' '^examples/'
+            '-e' '^(VERSION|LICENSE)$'
+            '-e' '\.md$'
+)
+
+
+BRANCHING_POINT=$(getBranchingPoint HEAD origin/master)
+SRC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD.."${BRANCHING_POINT}" | grep -cEv "${DOC_EXAMPLE_CHANGE_PATTERN[@]}") || true
+
+if [[ "${SRC_CHANGES}" -eq 0 ]]; then
+  echo "Skipping CI build"
+  circleci step halt
+else
+  echo "Continuing CI build"
+fi


### PR DESCRIPTION
Currently we run all our tests every time we open a PR,
we should skip running that if only documentation change was made,
or one of the examples was changed.

Fixes #143 