### PR TITLE
CI: Manually fix CI build

### DIFF
--- a/hack/check-skippable-changes.sh
+++ b/hack/check-skippable-changes.sh
@@ -25,9 +25,12 @@ DOC_EXAMPLE_CHANGE_PATTERN=(
 
 BRANCHING_POINT=$(getBranchingPoint HEAD origin/master)
 SRC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD.."${BRANCHING_POINT}" | grep -cEv "${DOC_EXAMPLE_CHANGE_PATTERN[@]}") || true
+HEAD=$(git rev-parse HEAD)
+MASTER=$(git rev-parse origin/master)
 
-if [[ "${SRC_CHANGES}" -eq 0 ]] && [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
-  # Skip build because only documentation and examples changed and this is a PR
+if [[ "${SRC_CHANGES}" -eq 0 ]] && [[ "${HEAD}" != "${MASTER}" ]]; then
+  # Skip build because only documentation and examples changed
+  # and the current HEAD is not master, implying that this is a PR and not a merge
   echo "Skipping CI build"
   circleci step halt
 else


### PR DESCRIPTION
The CIRCLE_PULL_REQUEST variable has some problems with not being set,
so comparing head to master seems to be the better idea in ensuring that
the current build does not skip in a merge.
https://discuss.circleci.com/t/circle-pull-request-not-being-set/14409/21
