### PR TITLE
Remove count restriction in leader topology

### DIFF
--- a/examples/leader/README.md
+++ b/examples/leader/README.md
@@ -8,6 +8,6 @@ Simply run:
 
   `kubectl create -f examples/leader/habitat.yml`.
 
-This will deploy 3 instances of Redis Habitat service.
+This will deploy 1 instance of Redis Habitat service.
 
-Note: Whenever creating a `leader` topology specify instance `count` of 3 or more and would be best if the number is odd, this is so the election can take place.
+Note: To have functioning services in the `leader` topology, you must set the `count` field to at least 3. It is recommended that the number is odd as this prevents a split quorum during the leader election.

--- a/examples/leader/habitat.yml
+++ b/examples/leader/habitat.yml
@@ -10,8 +10,10 @@ spec:
   v1beta2:
     # the core/redis habitat service packaged as a Docker image
     image: habitat/redis-hab
-    # count must be at least 3 for a leader-follower topology
-    count: 3
+    # While it is possible to deploy only one pod with a service
+    # instance in the leader-follower topology, at least 3 instances
+    # are required for services to be started by the supervisor.
+    count: 1
     service:
       name: redis
       topology: leader

--- a/pkg/controller/v1beta1/utils.go
+++ b/pkg/controller/v1beta1/utils.go
@@ -34,10 +34,9 @@ import (
 )
 
 const (
-	leaderFollowerTopologyMinCount = 3
-	pollInterval                   = 500 * time.Millisecond
-	timeOut                        = 10 * time.Second
-	habitatCRDName                 = habv1beta1.HabitatResourcePlural + "." + habitat.GroupName
+	pollInterval   = 500 * time.Millisecond
+	timeOut        = 10 * time.Second
+	habitatCRDName = habv1beta1.HabitatResourcePlural + "." + habitat.GroupName
 )
 
 type keyNotFoundError struct {
@@ -54,9 +53,6 @@ func validateCustomObject(h habv1beta1.Habitat) error {
 	switch spec.Service.Topology {
 	case habv1beta1.TopologyStandalone:
 	case habv1beta1.TopologyLeader:
-		if spec.Count < leaderFollowerTopologyMinCount {
-			return fmt.Errorf("too few instances: %d, leader-follower topology requires at least %d", spec.Count, leaderFollowerTopologyMinCount)
-		}
 	default:
 		return fmt.Errorf("unknown topology: %s", spec.Service.Topology)
 	}

--- a/pkg/controller/v1beta2/utils.go
+++ b/pkg/controller/v1beta2/utils.go
@@ -31,10 +31,9 @@ import (
 )
 
 const (
-	leaderFollowerTopologyMinCount = 3
-	pollInterval                   = 500 * time.Millisecond
-	timeOut                        = 10 * time.Second
-	habitatCRDName                 = habv1beta1.HabitatResourcePlural + "." + habitat.GroupName
+	pollInterval   = 500 * time.Millisecond
+	timeOut        = 10 * time.Second
+	habitatCRDName = habv1beta1.HabitatResourcePlural + "." + habitat.GroupName
 )
 
 type keyNotFoundError struct {
@@ -54,9 +53,6 @@ func validateCustomObject(h habv1beta1.Habitat) error {
 	switch spec.Service.Topology {
 	case habv1beta1.TopologyStandalone:
 	case habv1beta1.TopologyLeader:
-		if spec.Count < leaderFollowerTopologyMinCount {
-			return fmt.Errorf("too few instances: %d, leader-follower topology requires at least %d", spec.Count, leaderFollowerTopologyMinCount)
-		}
 	default:
 		return fmt.Errorf("unknown topology: %s", spec.Service.Topology)
 	}


### PR DESCRIPTION
While atleast three instances are required for a functioning cluster
in the leader topology, we should not prevent users from making
deployments with initial count set to one. This change allows users to
incrementally add instances if that fits their requirements better
instead of forcing them to add atleast three right from the onset.

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>