### PR TITLE
example: Add patch to events in rbac example

### DIFF
--- a/examples/rbac/rbac.yml
+++ b/examples/rbac/rbac.yml
@@ -56,4 +56,4 @@ rules:
 - apiGroups: [""]
   resources:
   - events
-  verbs: [ "create" ]
+  verbs: [ "create", "patch" ]


### PR DESCRIPTION
Deployments in an RBAC enabled cluster were returning the following
error:

```
User "system:serviceaccount:default:habitat-operator" cannot patch events in the namespace "default"' (will not retry!)
```

This commit fixes this error.

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>