### PR TITLE
controller: Write multiple IP to peer-watch-file

### DIFF
--- a/pkg/controller/v1beta1/controller.go
+++ b/pkg/controller/v1beta1/controller.go
@@ -533,7 +533,7 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 	maxPods := int(math.Min(float64(maxPeerFileAddresses), float64(len(runningPods))))
 	ipAddresses := make([]string, maxPods)
 	for i := 0; i < maxPods; i++ {
-		ipAddresses = append(ipAddresses, runningPods[i].Status.PodIP)
+		ipAddresses[i] = runningPods[i].Status.PodIP
 	}
 
 	ipAddressesStr := strings.Join(ipAddresses, "\n")

--- a/pkg/controller/v1beta1/controller.go
+++ b/pkg/controller/v1beta1/controller.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +50,8 @@ const (
 	peerFilename  = "peer-ip"
 	peerFile      = "peer-watch-file"
 	configMapName = peerFile
+	// The maximum number of IP addresses to be written to the peer-watch-file.
+	maxPeerFileAddresses = 5
 
 	// The key under which the ring key is stored in the Kubernetes Secret.
 	ringSecretKey = "ring-key"
@@ -525,9 +529,15 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 	}
 
 	// There are running Pods, add the IP of one of them to the ConfigMap.
-	leaderIP := runningPods[0].Status.PodIP
+	ipAddresses := make([]string, 0)
+	maxPods := int(math.Min(float64(maxPeerFileAddresses), float64(len(runningPods))))
 
-	newCM := newConfigMap(leaderIP, h)
+	for i := 0; i < maxPods; i++ {
+		ipAddresses = append(ipAddresses, runningPods[i].Status.PodIP)
+	}
+
+	ipAddressesStr := strings.Join(ipAddresses, "\n")
+	newCM := newConfigMap(ipAddressesStr, h)
 
 	cm, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(h.Namespace).Create(newCM)
 	if err != nil {
@@ -543,25 +553,13 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 			return err
 		}
 
-		curLeader := cm.Data[peerFile]
-
-		for _, p := range runningPods {
-			if p.Status.PodIP == curLeader {
-				// The leader is still up, nothing to do.
-				level.Debug(hc.logger).Log("msg", "Leader still running", "ip", curLeader)
-
-				return nil
-			}
-		}
-
-		// The leader is not in the list of running Pods, so the ConfigMap must be updated.
-		if err := hc.writeLeaderIP(cm, leaderIP); err != nil {
+		if err := hc.writeLeaderIP(cm, ipAddressesStr); err != nil {
 			return err
 		}
 
-		level.Info(hc.logger).Log("msg", "updated peer IP in ConfigMap", "name", cm.Name, "ip", leaderIP)
+		level.Info(hc.logger).Log("msg", "updated peer IP in ConfigMap", "name", cm.Name, "ip", ipAddressesStr)
 	} else {
-		level.Info(hc.logger).Log("msg", "created peer IP ConfigMap", "name", cm.Name, "ip", leaderIP)
+		level.Info(hc.logger).Log("msg", "created peer IP ConfigMap", "name", cm.Name, "ip", ipAddressesStr)
 	}
 
 	return nil

--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -484,7 +484,7 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 	maxPods := int(math.Min(float64(maxPeerFileAddresses), float64(len(runningPods))))
 	ipAddresses := make([]string, maxPods)
 	for i := 0; i < maxPods; i++ {
-		ipAddresses = append(ipAddresses, runningPods[i].Status.PodIP)
+		ipAddresses[i] = runningPods[i].Status.PodIP
 	}
 
 	ipAddressesStr := strings.Join(ipAddresses, "\n")

--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -429,7 +429,7 @@ func (hc *HabitatController) getRunningPods(namespace string) ([]apiv1.Pod, erro
 	return pods.Items, nil
 }
 
-func (hc *HabitatController) writeLeaderIP(cm *apiv1.ConfigMap, ip string) error {
+func (hc *HabitatController) writeToPeerFile(cm *apiv1.ConfigMap, ip string) error {
 	cm.Data[peerFile] = ip
 
 	if _, err := hc.config.KubernetesClientset.CoreV1().ConfigMaps(cm.Namespace).Update(cm); err != nil {
@@ -463,7 +463,7 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 				return err
 			}
 
-			if err := hc.writeLeaderIP(cm, ""); err != nil {
+			if err := hc.writeToPeerFile(cm, ""); err != nil {
 				return err
 			}
 
@@ -479,10 +479,10 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 		return nil
 	}
 
-	// There are running Pods, add the IP of one of them to the ConfigMap.
-	ipAddresses := make([]string, 0)
+	// There are running Pods, add their IP to the ConfigMap but
+	// limit it to a maxiumum of maxPeerFileAddresses.
 	maxPods := int(math.Min(float64(maxPeerFileAddresses), float64(len(runningPods))))
-
+	ipAddresses := make([]string, maxPods)
 	for i := 0; i < maxPods; i++ {
 		ipAddresses = append(ipAddresses, runningPods[i].Status.PodIP)
 	}
@@ -497,14 +497,21 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 			return err
 		}
 
-		// The ConfigMap already exists. Retrieve it and find out if the the leader
-		// is still running.
+		// The ConfigMap already exists. Retrieve it and find
+		// out if there has been a change in the running pods
+		// since the last time the ConfigMap was updated.
 		cm, err := hc.findConfigMapInCache(newCM)
 		if err != nil {
 			return err
 		}
 
-		if err := hc.writeLeaderIP(cm, ipAddressesStr); err != nil {
+		currPeerFileData := cm.Data[peerFile]
+		if ipAddressesStr == cm.Data[peerFile] {
+			level.Debug(hc.logger).Log("msg", "Running pods have not changed", "ip", currPeerFileData)
+			return nil
+		}
+
+		if err := hc.writeToPeerFile(cm, ipAddressesStr); err != nil {
 			return err
 		}
 

--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -482,9 +482,9 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 	// There are running Pods, add their IP to the ConfigMap but
 	// limit it to a maxiumum of maxPeerFileAddresses.
 	maxPods := int(math.Min(float64(maxPeerFileAddresses), float64(len(runningPods))))
-	ipAddresses := make([]string, maxPods)
+	ipAddresses := make([]string, 0, maxPods)
 	for i := 0; i < maxPods; i++ {
-		ipAddresses[i] = runningPods[i].Status.PodIP
+		ipAddresses = append(ipAddresses, runningPods[i].Status.PodIP)
 	}
 
 	ipAddressesStr := strings.Join(ipAddresses, "\n")
@@ -497,16 +497,24 @@ func (hc *HabitatController) handleConfigMap(h *habv1beta1.Habitat) error {
 			return err
 		}
 
-		// The ConfigMap already exists. Retrieve it and find
-		// out if there has been a change in the running pods
-		// since the last time the ConfigMap was updated.
+		// The ConfigMap already exists. Retrieve it and find out if
+		// there has been a change in the running pods since the last
+		// time the ConfigMap was updated.
 		cm, err := hc.findConfigMapInCache(newCM)
 		if err != nil {
 			return err
 		}
 
+		// By default, the list of pods returned via the Kubernetes API
+		// is sorted in alphabetical order. As a result we rely on this
+		// ordering to recreate the string of IPs and do a simple string
+		// comparison to see if anything has changed. The string would
+		// be different if any pods were added, removed or rescheduled
+		// since the last time we updated the ConfigMap. This approach
+		// helps keep the code simpler than maintaining a set of pod IPs
+		// and checking if they are truly identical or not.
 		currPeerFileData := cm.Data[peerFile]
-		if ipAddressesStr == cm.Data[peerFile] {
+		if ipAddressesStr == currPeerFileData {
 			level.Debug(hc.logger).Log("msg", "Running pods have not changed", "ip", currPeerFileData)
 			return nil
 		}


### PR DESCRIPTION
Problem: While implementing multiple instances in the
habitat-service-broker we noticed that the supervisors get stuck in
the leader election phase when applying a service binding. This
happens as the StatefulSet uses a RollingUpdate strategy for
updating the deployment. As a result, while each pod is updated at a
time, it appears at the moment that the supervisors running in the
pods have a stale copy of the peer-watch-file. How this happens is not
very clear at the moment, but our understanding is that this may be
the result of the supervisors not listening for changes to the
peer-watch-file once they have joined the ring. This can be fixed in
the habitat supervisor but would likely require additional brain
storming.

At the moment, we write only one IP address from the list of
running pods to the peer-watch-file. This increases the likelihood
that if the pod whose IP address is in the peer-watch-file is deleted,
other supervisors would still have the stale copy of the
peer-watch-file as they have already joined the ring before this pod
was deleted and have stopped listening for changes to the file.

Solution: (More like a workaround) We are changing this approach by
writing multiple pod IP addresses to the peer-watch-file instead of a
single one. This was found to have fixed the bug where the supervisors
get stuck in the leader election phase as even if a pod is deleted,
there are other pods from the list in peer-watch-file actively
running.

Food for thought: In our tests with minikube, it was found that deleted pods
once rescheduled were allocated the same IP address as the one it had
before being deleted, provided no other pods were started or deleted
in the meantime. While this is not guaranteed, it was expected that
the supervisors would have resumed operation without getting stuck as
rescheduling a pod and ending up with the same IP would mean nothing
changed in the network from the perspective of the supervisors already
running. This might warrant a closer look at the ring
formation/joining and leader election of the supervisors.

Signed-off-by: Indradhanush Gupta <indra@kinvolk.io>