### PR TITLE
Enable test for persistent storage

### DIFF
--- a/test/e2e/v1beta1/operator_test.go
+++ b/test/e2e/v1beta1/operator_test.go
@@ -216,15 +216,12 @@ func TestHabitatDelete(t *testing.T) {
 }
 
 func TestPersistentStorage(t *testing.T) {
-	// We run minikube in a VM on the CI infrastructure. In that environment, we cannot create PersistentVolumes.
-	t.Skip("This test cannot be run successfully in our current testing setup")
-
 	ephemeral, err := utils.ConvertHabitat("resources/standalone/habitat.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	persisted, err := utils.ConvertHabitat("resources/persisted/habitat.yml")
+	persisted, err := utils.ConvertHabitat("resources/persistent/habitat.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,6 +251,13 @@ func TestPersistentStorage(t *testing.T) {
 			t.Fatal(err)
 		}
 	})(persisted.Name)
+
+	// Delete the ephemeral resource created
+	defer (func(name string) {
+		if err := framework.DeleteHabitat(name); err != nil {
+			t.Fatal(err)
+		}
+	})(ephemeral.Name)
 
 	if err := framework.WaitForResources(habv1beta1.HabitatNameLabel, persisted.Name, 1); err != nil {
 		t.Fatal(err)

--- a/test/e2e/v1beta1/resources/persistent/habitat.yml
+++ b/test/e2e/v1beta1/resources/persistent/habitat.yml
@@ -2,13 +2,14 @@ apiVersion: habitat.sh/v1beta1
 kind: Habitat
 metadata:
   name: persisted-test
+customVersion: v1beta2
 spec:
   v1beta2:
     image: kinvolk/redis-hab
     count: 1
     persistentStorage:
       size: 100Mi
-      # created by minikube
+      # created by default on GCP
       storageClassName: standard
       mountPath: /tmp/foo
     service:


### PR DESCRIPTION
We no longer run tests using minikube in a VM on the CI infrastructure
but with GCP

Fixes #292 

Depends on #302 