### PR TITLE
Run e2e tests on multiple versions of kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,94 +1,117 @@
-version: 2
-jobs:
-  build:
-    machine: true
-    working_directory: ~/.go_workspace/src/github.com/habitat-sh/habitat-operator
-    steps:
-      - checkout
-      - run:
-          name: Check for changes in documentation and examples
-          command: ./hack/check-skippable-changes.sh
-      - run:
-          name: Setup environment variables
-          command: |
-            echo 'export IMAGE_NAME=eu.gcr.io/$GCLOUD_PROJECT_ID/habitat/habitat-operator-$CIRCLE_BUILD_NUM' >>"${BASH_ENV}"
-            echo 'export IMAGE_TAG=testing' >>"${BASH_ENV}"
-            echo 'export IMAGE_FULL_NAME="${IMAGE_NAME}:${IMAGE_TAG}"' >>"${BASH_ENV}"
-      - run:
-          name: setup kubectl
-          environment:
-            K8S_VERSION: v1.10.0
-          command: |
-            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - run:
-          name: code-gen script
-          environment:
-            CODEGEN_PKG: ../../../../src/k8s.io/code-generator
-            CODEGEN_VERSION: kubernetes-1.10.0
-            GOPATH: /home/circleci/.go_workspace
-          command: |
+defaults: &defaults
+  machine: true
+  working_directory: ~/.go_workspace/src/github.com/habitat-sh/habitat-operator
+  steps:
+    - checkout
+    - run:
+        name: Check for changes in documentation and examples
+        command: ./hack/check-skippable-changes.sh
+    - run:
+        name: Setup environment variables
+        command: |
+          echo 'export IMAGE_NAME=eu.gcr.io/$GCLOUD_PROJECT_ID/habitat/habitat-operator-$CIRCLE_BUILD_NUM' >>"${BASH_ENV}"
+          echo 'export IMAGE_TAG=testing' >>"${BASH_ENV}"
+          echo 'export IMAGE_FULL_NAME="${IMAGE_NAME}:${IMAGE_TAG}"' >>"${BASH_ENV}"
+    - run:
+        name: setup kubectl
+        command: |
+          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+    - run:
+        name: code-gen script
+        environment:
+          CODEGEN_PKG: ../../../../src/k8s.io/code-generator
+          GOPATH: /home/circleci/.go_workspace
+        command: |
+          if [[ -n $CODEGEN_VERSION ]]; then
             mkdir -p $CODEGEN_PKG
             git clone https://github.com/kubernetes/code-generator.git --branch $CODEGEN_VERSION $GOPATH/src/k8s.io/code-generator
             hack/verify-codegen.sh
-      - run:
-          name: unit tests
-          command: make test
-      - run:
-          name: install google cloud sdk
-          command: |
-            sudo apt-get install lsb-release
-            CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-            echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-            sudo apt-get update && sudo apt-get install google-cloud-sdk
+          else
+            echo "Skipping codegen checks..."
+          fi
+    - run:
+        name: unit tests
+        command: make test
+    - run:
+        name: install google cloud sdk
+        command: |
+          sudo apt-get install lsb-release
+          CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+          echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+          sudo apt-get update && sudo apt-get install google-cloud-sdk
 
-            # the GCLOUD_SERVICE_KEY environment variable is set in the web UI
-            echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+          # the GCLOUD_SERVICE_KEY environment variable is set in the web UI
+          echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
 
-            # setup SDK
-            gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-            # GCLOUD_PROJECT_ID is set in Circle CI web UI
-            gcloud config set project $GCLOUD_PROJECT_ID
-            gcloud config set compute/zone europe-west1-b
-      - run:
-          name: Update gcloud components
-          command: sudo /opt/google-cloud-sdk/bin/gcloud components update --quiet
-      - run:
-          name: boot cluster on gke
-          environment:
-            GKE_CLUSTER_VERSION: 1.10.4-gke.2
-          command: gcloud container clusters create --cluster-version=$GKE_CLUSTER_VERSION --disk-size=20 operator-test-$CIRCLE_BUILD_NUM
-      - run:
-          name: create image
-          command: make IMAGE=$IMAGE_NAME TAG=$IMAGE_TAG image
-      - run:
-          name: Configure docker to use gcloud to authenticate requests to Container Registry
-          command: gcloud auth configure-docker
-      - run:
-          name: Push the docker image
-          command: docker push $IMAGE_FULL_NAME
-      - run:
-          name: waiting for kubernetes to be ready
-          command: |
-            JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-            until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
-              sleep 1
-            done
-      - run:
-          name: Grant the user the ability to create authorization roles
-          command: kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
-      - run:
-          name: e2e tests
-          command: make TESTIMAGE=$IMAGE_FULL_NAME e2e
-      - run:
-          name: print habitat object logs
-          command: kubectl logs -lhabitat-operator=true --tail=100
-          when: on_fail
-      - run:
-          name: Delete image from Container Registry
-          command: gcloud container images delete $IMAGE_FULL_NAME --force-delete-tags --quiet
-          when: always
-      - run:
-          name: delete cluster on gke
-          command: gcloud container clusters delete operator-test-$CIRCLE_BUILD_NUM --quiet
-          when: always
+          # setup SDK
+          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+          # GCLOUD_PROJECT_ID is set in Circle CI web UI
+          gcloud config set project $GCLOUD_PROJECT_ID
+          gcloud config set compute/zone europe-west1-b
+    - run:
+        name: Update gcloud components
+        command: sudo /opt/google-cloud-sdk/bin/gcloud components update --quiet
+    - run:
+        name: boot cluster on gke
+        command: gcloud container clusters create --cluster-version=$GKE_CLUSTER_VERSION --disk-size=20 operator-test-$CIRCLE_BUILD_NUM
+    - run:
+        name: create image
+        command: make IMAGE=$IMAGE_NAME TAG=$IMAGE_TAG image
+    - run:
+        name: Configure docker to use gcloud to authenticate requests to Container Registry
+        command: gcloud auth configure-docker
+    - run:
+        name: Push the docker image
+        command: docker push $IMAGE_FULL_NAME
+    - run:
+        name: waiting for kubernetes to be ready
+        command: |
+          JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+          until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+            sleep 1
+          done
+    - run:
+        name: Grant the user the ability to create authorization roles
+        command: kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
+    - run:
+        name: e2e tests
+        command: make TESTIMAGE=$IMAGE_FULL_NAME e2e
+    - run:
+        name: print habitat object logs
+        command: kubectl logs -lhabitat-operator=true --tail=100
+        when: on_fail
+    - run:
+        name: Delete image from Container Registry
+        command: gcloud container images delete $IMAGE_FULL_NAME --force-delete-tags --quiet
+        when: always
+    - run:
+        name: delete cluster on gke
+        command: gcloud container clusters delete operator-test-$CIRCLE_BUILD_NUM --quiet
+        when: always
+
+jobs:
+  k8s-v1.10:
+    environment:
+      K8S_VERSION: v1.10.0
+      GKE_CLUSTER_VERSION: 1.10.5-gke.0
+      CODEGEN_VERSION: kubernetes-1.10.0
+    <<: *defaults
+  k8s-v1.9:
+    environment:
+      K8S_VERSION: v1.9.0
+      GKE_CLUSTER_VERSION: 1.9.7-gke.3
+    <<: *defaults
+  k8s-v1.8:
+    environment:
+      K8S_VERSION: v1.8.0
+      GKE_CLUSTER_VERSION: 1.8.10-gke.0
+    <<: *defaults
+
+workflows:
+  version: 2
+  all-k8s-tests:
+    jobs:
+      - k8s-v1.10
+      - k8s-v1.9
+      - k8s-v1.8

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -31,14 +31,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-${CODEGEN_PKG}/generate-groups.sh all \
+"${CODEGEN_PKG}"/generate-groups.sh all \
   github.com/habitat-sh/habitat-operator/pkg/client github.com/habitat-sh/habitat-operator/pkg/apis \
   habitat:v1beta1 \
-  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
+  --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate.go.txt

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -23,7 +23,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 "${SCRIPT_ROOT}/hack/update-codegen.sh"
 echo "Checking against freshly generated codegen..."
@@ -32,8 +32,7 @@ ret=0
 
 git diff --quiet "*.deepcopy.go" || ret=$?
 
-if [[ $ret -eq 0 ]]
-then
+if [[ $ret -eq 0 ]]; then
   echo "  Up to date."
 else
   echo "  Out of date. Please run hack/update-codegen.sh"


### PR DESCRIPTION
Needs #303 to be merged first

Fixes #304 and #238 

This PR adds support for the tests to run successfully on k8s v1.8 and 1.9 alongside v1.10.