### PR TITLE
Delete pods if StatefulSet object is updated

### DIFF
--- a/examples/rbac/rbac.yml
+++ b/examples/rbac/rbac.yml
@@ -48,7 +48,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "deletecollection"]
 - apiGroups: [""]
   resources:
   - namespaces

--- a/helm/habitat-operator/templates/clusterrole.yaml
+++ b/helm/habitat-operator/templates/clusterrole.yaml
@@ -42,7 +42,7 @@ rules:
 - apiGroups: [""]
   resources:
   - pods
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "deletecollection"]
 - apiGroups: [""]
   resources:
   - namespaces

--- a/pkg/controller/v1beta2/stateful_sets.go
+++ b/pkg/controller/v1beta2/stateful_sets.go
@@ -147,6 +147,13 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 					},
 				},
 			},
+			// We delete pods manually in the controller when StatefulSet
+			// objects are updated. Setting UpdateStrategy to OnDelete
+			// prevents us messing with the StatefulSet controller when
+			// StatefulSet is updated.
+			UpdateStrategy: appsv1beta2.StatefulSetUpdateStrategy{
+				Type: appsv1beta2.OnDeleteStatefulSetStrategyType,
+			},
 		},
 	}
 


### PR DESCRIPTION
A supervisor bug prevents pods from successfully completing a leader
election when an update is made to the StatefulSet object. This arises
from the RollingUpdate behaviour of StatefulSet.

However, deleting them all at once fixes the problem. In this commit
we compare the older StatefulSet object with the updated one and
delete all pods that belong to that object if the StatefulSet objects
before and after the update are different. This check was necessary
because the StatefulSet keeps getting updated even though nothing has
changed as a result of the ConfigMap cache getting updated frequently.

More about the bug here: habitat-sh/habitat#5264