### PR TITLE
controller: Fix usage of LabelSelector

### DIFF
--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -772,8 +772,10 @@ func (hc *HabitatController) findConfigMapInCache(cm *apiv1.ConfigMap) (*apiv1.C
 }
 
 func (hc *HabitatController) deleteStatefulSetPods(sts *appsv1beta2.StatefulSet) error {
+	fs := fields.SelectorFromSet(fields.Set(sts.Spec.Selector.MatchLabels))
+
 	listOptions := metav1.ListOptions{
-		LabelSelector: sts.Spec.Selector.String(),
+		LabelSelector: fs.String(),
 	}
 
 	return hc.config.KubernetesClientset.CoreV1().


### PR DESCRIPTION
`sts.Spec.Selector` is a `map[string]string`.

This leads to the following error on deleting pods:
```
ts=2018-07-10T16:05:30.055388286Z level=error component=controller/v1beta2 msg="Habitat could not be synced, requeueing" err="unable to parse requirement: invalid label key \"&LabelSelector{MatchLabels:map[string]string{habitat-name:\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')" obj=redis-habitat/redis
```

This PR fixes it.