### PR TITLE
makefile: Ignore errors on clean test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ e2e:
 	go test -v ./test/e2e/... --image "$(TESTIMAGE)" --kubeconfig $(KUBECONFIG_PATH) --ip "$(IP)"
 
 clean-test:
-	kubectl delete namespace testing-v1beta1
-	kubectl delete clusterrolebinding habitat-operator-v1beta1
-	kubectl delete clusterrole habitat-operator-v1beta1
+	-kubectl delete namespace testing-v1beta1
+	-kubectl delete clusterrolebinding habitat-operator-v1beta1
+	-kubectl delete clusterrole habitat-operator-v1beta1
 
 update-version:
 	find examples -name "*.yml" -type f \


### PR DESCRIPTION
Makefile can ignore commands if failed. `clean-test` target deletes
the namespaces. But if the namespace does not exist then kubectl
command fails and so does the clean process.

This commit ignores the error returned by kubectl. And continues
with the rest of the commands.