### PR TITLE
[topology label] add new label `operator.habitat.sh/topology` 

### DIFF
--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -30,7 +30,8 @@ const (
 	// Example: 'habitat-name: db'
 	HabitatNameLabel = "habitat-name"
 
-	TopologyLabel = "topology"
+	TopologyLabel        = "topology"
+	HabitatTopologyLabel = "operator.habitat.sh/topology"
 )
 
 // +genclient

--- a/pkg/controller/v1beta2/stateful_sets.go
+++ b/pkg/controller/v1beta2/stateful_sets.go
@@ -105,9 +105,10 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						habv1beta1.HabitatLabel:     "true",
-						habv1beta1.HabitatNameLabel: h.Name,
-						habv1beta1.TopologyLabel:    topology.String(),
+						habv1beta1.HabitatLabel:         "true",
+						habv1beta1.HabitatNameLabel:     h.Name,
+						habv1beta1.TopologyLabel:        topology.String(),
+						habv1beta1.HabitatTopologyLabel: topology.String(),
 					},
 				},
 				Spec: apiv1.PodSpec{


### PR DESCRIPTION
Renaming the topology label from just `topology` to
`operator.habitat.sh/topology`.

Fixes https://github.com/habitat-sh/habitat-operator/issues/309