### PR TITLE
[GKE versioning] Update GKE version used to run e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,18 +117,18 @@ jobs:
   k8s-v1.10:
     environment:
       K8S_VERSION: v1.10.0
-      GKE_CLUSTER_VERSION: 1.10.5-gke.0
+      GKE_CLUSTER_VERSION: "1.10"
       CODEGEN_VERSION: kubernetes-1.10.0
     <<: *defaults
   k8s-v1.9:
     environment:
       K8S_VERSION: v1.9.0
-      GKE_CLUSTER_VERSION: 1.9.7-gke.3
+      GKE_CLUSTER_VERSION: "1.9"
     <<: *defaults
   k8s-v1.8:
     environment:
       K8S_VERSION: v1.8.0
-      GKE_CLUSTER_VERSION: 1.8.10-gke.0
+      GKE_CLUSTER_VERSION: "1.8"
     <<: *defaults
 
 workflows:


### PR DESCRIPTION
Right now the cluster versions provided are specific. But GKE allows
us to provide a version which follows versioning like `1.8` or `1.9`.

> 1.X: picks the highest valid patch+gke.N patch in the 1.X version

Above is the line copied from the GKE documentation:
https://cloud.google.com/kubernetes-engine/versioning-and-upgrades

So this commit changes the versioning to `1.8`, `1.9`, `1.10`.

---

**Note**: The versions are put in double quote, because those fields were interpreted as `float` as opposed to `string`.