### PR TITLE
[controller]: move StatefulSet from v1beta1 to v1

### DIFF
--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -617,17 +617,17 @@ func (hc *HabitatController) conform(key string) error {
 	}
 
 	// Create StatefulSet, if it doesn't already exist.
-	if _, err := hc.config.KubernetesClientset.AppsV1beta2().StatefulSets(h.Namespace).Create(newSts); err != nil {
+	if _, err := hc.config.KubernetesClientset.AppsV1().StatefulSets(h.Namespace).Create(newSts); err != nil {
 		// Was the error due to the StatefulSet already existing?
 		if apierrors.IsAlreadyExists(err) {
 			// If yes, update it but retrieve the current state before that.
-			oldSts, err := hc.config.KubernetesClientset.AppsV1beta2().StatefulSets(h.Namespace).Get(newSts.Name, metav1.GetOptions{})
+			oldSts, err := hc.config.KubernetesClientset.AppsV1().StatefulSets(h.Namespace).Get(newSts.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
 			// Update the StatefulSet
-			updatedSts, err := hc.config.KubernetesClientset.AppsV1beta2().StatefulSets(h.Namespace).Update(newSts)
+			updatedSts, err := hc.config.KubernetesClientset.AppsV1().StatefulSets(h.Namespace).Update(newSts)
 			if err != nil {
 				return err
 			}
@@ -776,7 +776,7 @@ func (hc *HabitatController) findConfigMapInCache(cm *apiv1.ConfigMap) (*apiv1.C
 	return obj.(*apiv1.ConfigMap), nil
 }
 
-func (hc *HabitatController) deleteStatefulSetPods(sts *appsv1beta2.StatefulSet) error {
+func (hc *HabitatController) deleteStatefulSetPods(sts *appsv1.StatefulSet) error {
 	fs := fields.SelectorFromSet(fields.Set(sts.Spec.Selector.MatchLabels))
 
 	listOptions := metav1.ListOptions{

--- a/pkg/controller/v1beta2/stateful_sets.go
+++ b/pkg/controller/v1beta2/stateful_sets.go
@@ -20,7 +20,7 @@ import (
 	habv1beta1 "github.com/habitat-sh/habitat-operator/pkg/apis/habitat/v1beta1"
 
 	"github.com/go-kit/kit/log/level"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +29,7 @@ import (
 
 const persistentVolumeName = "persistent"
 
-func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2.StatefulSet, error) {
+func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1.StatefulSet, error) {
 	hs := h.Spec.V1beta2
 
 	// This value needs to be passed as a *int32, so we convert it, assign it to a
@@ -78,7 +78,7 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 			"--bind", bindArg)
 	}
 
-	base := &appsv1beta2.StatefulSet{
+	base := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: h.Name,
 			Labels: map[string]string{
@@ -94,14 +94,14 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 				},
 			},
 		},
-		Spec: appsv1beta2.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					habv1beta1.HabitatNameLabel: h.Name,
 				},
 			},
 			Replicas:            &count,
-			PodManagementPolicy: appsv1beta2.ParallelPodManagement,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -152,8 +152,8 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 			// objects are updated. Setting UpdateStrategy to OnDelete
 			// prevents us messing with the StatefulSet controller when
 			// StatefulSet is updated.
-			UpdateStrategy: appsv1beta2.StatefulSetUpdateStrategy{
-				Type: appsv1beta2.OnDeleteStatefulSetStrategyType,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},
 		},
 	}
@@ -286,7 +286,7 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1beta2
 }
 
 func (hc *HabitatController) cacheStatefulSets() {
-	hc.stsInformer = hc.config.KubeInformerFactory.Apps().V1beta2().StatefulSets().Informer()
+	hc.stsInformer = hc.config.KubeInformerFactory.Apps().V1().StatefulSets().Informer()
 
 	hc.stsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    hc.handleStsAdd,
@@ -298,7 +298,7 @@ func (hc *HabitatController) cacheStatefulSets() {
 }
 
 func (hc *HabitatController) handleStsAdd(obj interface{}) {
-	sts, ok := obj.(*appsv1beta2.StatefulSet)
+	sts, ok := obj.(*appsv1.StatefulSet)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert StatefulSet", "obj", obj)
 		return
@@ -314,13 +314,13 @@ func (hc *HabitatController) handleStsAdd(obj interface{}) {
 }
 
 func (hc *HabitatController) handleStsUpdate(oldObj, newObj interface{}) {
-	oldSTS, ok := oldObj.(*appsv1beta2.StatefulSet)
+	oldSTS, ok := oldObj.(*appsv1.StatefulSet)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert StatefulSet", "obj", oldObj)
 		return
 	}
 
-	newSTS, ok := newObj.(*appsv1beta2.StatefulSet)
+	newSTS, ok := newObj.(*appsv1.StatefulSet)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert StatefulSet", "obj", newObj)
 		return
@@ -341,7 +341,7 @@ func (hc *HabitatController) handleStsUpdate(oldObj, newObj interface{}) {
 }
 
 func (hc *HabitatController) handleStsDelete(obj interface{}) {
-	sts, ok := obj.(*appsv1beta2.StatefulSet)
+	sts, ok := obj.(*appsv1.StatefulSet)
 	if !ok {
 		level.Error(hc.logger).Log("msg", "Failed to type assert StatefulSet", "obj", obj)
 		return


### PR DESCRIPTION
The StatefulSets we generate are of version `v1beta1`, and
StatefulSets are stable in 1.9.

This commit adds support to generate `StatefulSet` of
version `v1` and not `v1beta1`.

Fixes https://github.com/habitat-sh/habitat-operator/issues/342