### PR TITLE
[RBAC] Remove permission for Deployments

### DIFF
--- a/examples/rbac/rbac.yml
+++ b/examples/rbac/rbac.yml
@@ -34,7 +34,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
   - statefulsets
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]

--- a/helm/habitat-operator/templates/clusterrole.yaml
+++ b/helm/habitat-operator/templates/clusterrole.yaml
@@ -28,7 +28,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
   - statefulsets
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]

--- a/test/e2e/v1beta1/resources/operator/cluster-role.yml
+++ b/test/e2e/v1beta1/resources/operator/cluster-role.yml
@@ -16,7 +16,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
   - statefulsets
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]


### PR DESCRIPTION
Habitat spec `v1beta1` needed to do CRUD on Deployments so it had
permissions on the Kubernetes Deployments resource.

Now that it's support is removed no more operations of Deployments
are done. Hence this commit removes the permission to Deployments.
