### PR TITLE
[Circle CI] Drop support of Kubernetes 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,6 @@ jobs:
       K8S_VERSION: v1.9.0
       GKE_CLUSTER_VERSION: "1.9"
     <<: *defaults
-  k8s-v1.8:
-    environment:
-      K8S_VERSION: v1.8.0
-      GKE_CLUSTER_VERSION: "1.8"
-    <<: *defaults
 
 workflows:
   version: 2
@@ -137,4 +132,3 @@ workflows:
     jobs:
       - k8s-v1.10
       - k8s-v1.9
-      - k8s-v1.8

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a more detailed description of the Habitat type have a look [here](https://g
 ## Prerequisites
 
 - Habitat `>= 0.52.0`
-- Kubernetes cluster with version `1.8.x`, `1.9.x` or `1.10.x`
+- Kubernetes cluster with version `1.9.x` or `1.10.x`
 - Kubectl version `1.9.x` or `1.10.x`
 
 ## Installing


### PR DESCRIPTION
This commit drops support of Kubernetes 1.8 as a supported
Kubernetes cluster for Habitat Operator. So to run Habitat Operator
the supported clusters from now on are 1.9 and 1.10.

Fixes https://github.com/habitat-sh/habitat-operator/issues/343