### PR TITLE
[version] Display version when booting operator

### DIFF
--- a/cmd/habitat-operator/main.go
+++ b/cmd/habitat-operator/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
@@ -37,6 +38,7 @@ import (
 	habclientset "github.com/habitat-sh/habitat-operator/pkg/client/clientset/versioned"
 	habinformers "github.com/habitat-sh/habitat-operator/pkg/client/informers/externalversions"
 	habv1beta2controller "github.com/habitat-sh/habitat-operator/pkg/controller/v1beta2"
+	"github.com/habitat-sh/habitat-operator/pkg/version"
 )
 
 const resyncPeriod = 30 * time.Second
@@ -228,6 +230,12 @@ func v1beta2(ctx context.Context, wg *sync.WaitGroup, cSets Clientsets, logger l
 	return nil
 }
 
+func printVersion() {
+	fmt.Printf("Go Version: %s\n", runtime.Version())
+	fmt.Printf("Operator Version: %s\n", version.VERSION)
+}
+
 func main() {
+	printVersion()
 	os.Exit(run())
 }

--- a/hack/publish-release.sh
+++ b/hack/publish-release.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 DRY_RUN=1
 readonly VERSION="v$(cat VERSION)"
 
+if [ "${VERSION}" != $(make print-version) ]; then
+  echo "Version in 'VERSION' file ${VERSION} & git tag $(make print-version) don't match! Follow the release steps mentioned in https://github.com/habitat-sh/habitat-operator/blob/master/doc/release-process.md"
+  exit 1
+fi
+
 run() {
   if [[ "${DRY_RUN}" -eq 1 ]]; then
     printf '%s\n' "$*"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+var (
+	VERSION = "HEAD"
+)


### PR DESCRIPTION
Operator shows it's version when it starts. This version information
is embedded inside the binary while building it. It is a good
practice to show the operator version when it is booting up.

Fixes https://github.com/habitat-sh/habitat-operator/issues/348