### PR TITLE
Add ability to mount /files directory from a secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 		github.com/$(GITHUB_ORG)/habitat-operator/cmd/habitat-operator
 
 .PHONY: linux
-linux:
+linux: build
 	# Compile statically linked binary for linux.
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s" \
 		-ldflags="-X github.com/$(GITHUB_ORG)/habitat-operator/pkg/version.VERSION=$(VERSION)" \

--- a/examples/files-volume/README.md
+++ b/examples/files-volume/README.md
@@ -1,0 +1,15 @@
+# Runtime binding
+
+This demonstrates how to provide the contents of the Habitat Service files directory via a Kubernetes Secret.
+
+
+## Workflow
+
+After the Habitat operator is up and running, execute the following command from the root of this repository:
+
+```
+kubectl create -f examples/files-volume/habitat.yml
+```
+
+This will deploy redis and also put a file containing a password into `hab/svc/redis/files/pwfile`.
+

--- a/examples/files-volume/habitat.yml
+++ b/examples/files-volume/habitat.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: files-secret
+type: Opaque
+data:
+  # base64 encoded string 'SecretPassword'
+  pwfile: U2VjcmV0UGFzc3dvcmQK
+---
+apiVersion: habitat.sh/v1beta1
+kind: Habitat
+metadata:
+  name: files-volume-habitat
+  labels:
+    source: operator-example
+    app: files-volume-habitat
+customVersion: v1beta2
+spec:
+  v1beta2:
+    image: habitat/redis-hab
+    count: 1
+    service:
+      name: redis
+      topology: standalone
+      group: redisdb
+      filesSecretName: files-secret

--- a/pkg/apis/habitat/v1beta1/types.go
+++ b/pkg/apis/habitat/v1beta1/types.go
@@ -103,6 +103,10 @@ type ServiceV1beta2 struct {
 	// The name of the secret that contains the ring key.
 	// +optional
 	RingSecretName *string `json:"ringSecretName,omitempty"`
+	// The name of a secret containing the files directory.  It will be mounted inside the pod
+	// as a directory.
+	// +optional
+	FilesSecretName *string `json:"filesSecretName,omitempty"`
 	// Bind is when one service connects to another forming a producer/consumer relationship.
 	// +optional
 	Bind []Bind `json:"bind,omitempty"`

--- a/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/habitat/v1beta1/zz_generated.deepcopy.go
@@ -176,6 +176,11 @@ func (in *ServiceV1beta2) DeepCopyInto(out *ServiceV1beta2) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FilesSecretName != nil {
+		in, out := &in.FilesSecretName, &out.FilesSecretName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Bind != nil {
 		in, out := &in.Bind, &out.Bind
 		*out = make([]Bind, len(*in))

--- a/pkg/controller/v1beta2/controller.go
+++ b/pkg/controller/v1beta2/controller.go
@@ -66,6 +66,8 @@ const (
 
 	userConfigFilename = "user-config"
 
+	filesDirectoryName = "files"
+
 	controllerAgentName = "habitat-controller"
 
 	// Events.

--- a/pkg/controller/v1beta2/stateful_sets.go
+++ b/pkg/controller/v1beta2/stateful_sets.go
@@ -213,7 +213,7 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1.Stat
 
 		// #1
 		filesSecretVolume := &apiv1.Volume{
-			Name: filesDirectoryName,
+			Name: "files-secrets",
 			VolumeSource: apiv1.VolumeSource{
 				Secret: &apiv1.SecretVolumeSource{
 					SecretName: files.Name,
@@ -223,7 +223,7 @@ func (hc *HabitatController) newStatefulSet(h *habv1beta1.Habitat) (*appsv1.Stat
 		tSpec.Volumes = append(tSpec.Volumes, *filesSecretVolume)
 
 		filesSecretVolumeMount := &apiv1.VolumeMount{
-			Name:      filesDirectoryName,
+			Name:      "files-secrets",
 			MountPath: "/mnt/files",
 		}
 


### PR DESCRIPTION
This adds the ability to mount the `/files` directory of a habitat service via a secret much like is done for config.  What is different is that we add all the files that are part of the secret.

This is useful for services that e.g. load certificates via `hab file upload` right now but want to do it via a k8s primitive.

Signed-off-by: James Casey <james@chef.io>