### PR TITLE
RBAC: revert the scope of operator to clusterwide

### DIFF
--- a/helm/habitat-operator/README.md
+++ b/helm/habitat-operator/README.md
@@ -65,7 +65,7 @@ Parameter | Description | Default
 `nodeSelector` | Node labels for pod assignment | `{}`
 `rbacEnable` | If true, create & use RBAC resources | `true`
 `resources` | Pod resource requests & limits | `{}`
-`operatorNamespaced` | If this operator should run scoped to Single namespace | `true`
+`operatorNamespaced` | If this operator should run scoped to Single namespace | `false`
 `namespace` | Namespace this operator should run inside | `habitat-operator`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/helm/habitat-operator/values.yaml
+++ b/helm/habitat-operator/values.yaml
@@ -14,7 +14,7 @@ nodeSelector: {}
 rbacEnable: true
 
 ## Decide if habitat-operator runs at cluster or namespaced scope
-operatorNamespaced: true
+operatorNamespaced: false
 namespace: habitat-operator
 
 ## Habitat-operator resource limits & requests

--- a/test/sync/rbac/sync_test.go
+++ b/test/sync/rbac/sync_test.go
@@ -168,9 +168,9 @@ func extractRulesFromHelm(path string, isItClusterRole bool) ([]rbacv1.PolicyRul
 		return nil, errors.Wrapf(err, "loading chart %s failed", path)
 	}
 
-	// make sure that the ClusterRole is generated
-	if isItClusterRole {
-		chart.Values.Raw = strings.Replace(chart.Values.Raw, "operatorNamespaced: true", "operatorNamespaced: false", 1)
+	// If it is Role then we need to replace the value of `operatorNamespaced` to true
+	if !isItClusterRole {
+		chart.Values.Raw = strings.Replace(chart.Values.Raw, "operatorNamespaced: false", "operatorNamespaced: true", 1)
 	}
 
 	renderedFiles, err := renderutil.Render(chart, chart.Values, renderutil.Options{})


### PR DESCRIPTION
This commit defaults the operator to run clusterwide by default. This
makes the operation of the operator to default as it was before the
RBAC was added.
